### PR TITLE
Feature/improve jsonrpc api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kubernetes-csi/csi-test/v5 v5.3.1
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
+	github.com/sourcegraph/jsonrpc2 v0.2.1
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.73.0
 	k8s.io/apimachinery v0.33.3

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -76,6 +77,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/sourcegraph/jsonrpc2 v0.2.1 h1:2GtljixMQYUYCmIg7W9aF2dFmniq/mOr2T9tFRh6zSQ=
+github.com/sourcegraph/jsonrpc2 v0.2.1/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/csi/controller.go
+++ b/pkg/csi/controller.go
@@ -88,7 +88,7 @@ func (cs *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVo
 	} else if errors.Is(err, ErrInconsistentSRs) {
 		return nil, status.Errorf(codes.FailedPrecondition, "inconsistent SRs found for storage selection")
 	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to find SRs: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to find SRs")
 	}
 
 	var vdi *xoa.VDI
@@ -102,7 +102,7 @@ func (cs *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVo
 	} else if errors.Is(err, xoa.ErrMultipleObjectsFound) {
 		return nil, status.Errorf(codes.AlreadyExists, "multiple disks found with same name already exist")
 	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get volume: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to get volume")
 	} else {
 		// volume exists, check if size matches
 		if foundVdi.Size != capacity {
@@ -115,7 +115,7 @@ func (cs *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVo
 	if vdi == nil {
 		createdVDI, err := cs.createDisk(ctx, storageSelection, volumeName, capacity, req.AccessibilityRequirements)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to create disk: %v", err)
+			return nil, translateXOAErrorToCSI(err, "failed to create disk")
 		}
 		vdi = createdVDI
 	}
@@ -124,13 +124,13 @@ func (cs *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVo
 	storageInfo := storageSelection.toStorageInfo()
 	err = cs.xoaClient.EditVDI(ctx, vdi.UUID, nil, ptr.To(storageInfo.ToVDIDescription()))
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to edit disk: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to edit disk")
 	}
 
 	// Find out the topology for the VDI
 	csiTopology, err := storageSelection.getTopologyForVDI(vdi)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get topology: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to get topology")
 	}
 
 	// Which reference we use for this type of volume
@@ -177,8 +177,10 @@ func (cs *ControllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVo
 			return &csi.DeleteVolumeResponse{}, nil
 		} else if errors.Is(err, xoa.ErrMultipleObjectsFound) {
 			return nil, status.Errorf(codes.Internal, "multiple VDIs found with same name")
+		} else if errors.Is(err, xoa.ErrObjectNotFound) {
+			return nil, status.Errorf(codes.NotFound, "volume not found")
 		} else if err != nil {
-			return nil, status.Errorf(codes.NotFound, "failed to get volume: %v", err)
+			return nil, translateXOAErrorToCSI(err, "failed to get volume")
 		}
 		vdiUUIDToDelete = vdi.UUID
 	case UUIDAsVolumeID:
@@ -188,7 +190,7 @@ func (cs *ControllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVo
 			// volume already deleted
 			return &csi.DeleteVolumeResponse{}, nil
 		} else if err != nil {
-			return nil, status.Errorf(codes.NotFound, "failed to get volume: %v", err)
+			return nil, translateXOAErrorToCSI(err, "failed to get volume")
 		}
 		vdiUUIDToDelete = vdiUUID
 	default:
@@ -200,7 +202,7 @@ func (cs *ControllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVo
 		// volume already deleted
 		return &csi.DeleteVolumeResponse{}, nil
 	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete volume: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to delete volume")
 	}
 
 	return &csi.DeleteVolumeResponse{}, nil
@@ -227,7 +229,7 @@ func (cs *ControllerService) ControllerPublishVolume(ctx context.Context, req *c
 	if errors.Is(err, xoa.ErrObjectNotFound) {
 		return nil, status.Errorf(codes.NotFound, "VM not found")
 	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get VM: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to get VM")
 	}
 
 	vbd, err := cs.checkDiskAttachment(ctx, vdi, vm)
@@ -248,7 +250,7 @@ func (cs *ControllerService) ControllerPublishVolume(ctx context.Context, req *c
 	} else if errors.Is(err, ErrInconsistentSRs) {
 		return nil, status.Errorf(codes.FailedPrecondition, "inconsistent SRs found for storage selection")
 	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to find SRs: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to find SRs")
 	}
 
 	log.Info("VDI is not attached to VM", "vdiUUID", vdi.UUID, "vmUUID", vmUUID)
@@ -257,13 +259,14 @@ func (cs *ControllerService) ControllerPublishVolume(ctx context.Context, req *c
 	if errors.Is(err, ErrSRNotValidForHost) {
 		return nil, status.Errorf(codes.FailedPrecondition, "SR is not valid for host %s", vm.Host)
 	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to check if migration is needed: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to check if migration is needed")
 	}
 
 	if needsMigration {
 		migratedvdi, _, err := cs.migrateVDI(ctx, vdi, vm, storageSelection)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to migrate VDI: %v", err)
+			// this error is already translated to CSI error
+			return nil, err
 		}
 		vdi = migratedvdi
 	}
@@ -279,10 +282,8 @@ func (cs *ControllerService) ControllerPublishVolume(ctx context.Context, req *c
 		return nil, status.Errorf(codes.AlreadyExists, "device already exists: %v", err)
 	} else if errors.Is(err, xoa.ErrOtherOperationInProgress) {
 		return nil, status.Errorf(codes.Unavailable, "other operation in progress: %v", err)
-	} else if errors.Is(err, context.DeadlineExceeded) {
-		return nil, status.Errorf(codes.DeadlineExceeded, "timeout while waiting for device: %v", err)
 	} else if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to publish disk: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to publish disk")
 	}
 
 	if vbd.Device == "" {
@@ -741,7 +742,7 @@ func (cs *ControllerService) checkDiskAttachment(ctx context.Context, vdi *xoa.V
 		} else if errors.Is(err, xoa.ErrOtherOperationInProgress) {
 			return nil, status.Errorf(codes.Unavailable, "other operation in progress: %v", err)
 		} else if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to connect VBD: %v", err)
+			return nil, translateXOAErrorToCSI(err, "failed to connect VBD")
 		}
 
 		return connectedVBD, nil
@@ -750,6 +751,8 @@ func (cs *ControllerService) checkDiskAttachment(ctx context.Context, vdi *xoa.V
 	return nil, nil
 }
 
+// migrateVDI: Migrate the VDI to the selected SR
+// returns CSI errors
 func (cs *ControllerService) migrateVDI(ctx context.Context, vdi *xoa.VDI, vm *xoa.VM, storageSelection *storageSelection) (*xoa.VDI, *xoa.SR, error) {
 	log, ctx := LogAndExpandContext(ctx, "action", "migrateVDI", "vdiUUID", vdi.UUID, "vmUUID", vm.UUID)
 
@@ -760,7 +763,7 @@ func (cs *ControllerService) migrateVDI(ctx context.Context, vdi *xoa.VDI, vm *x
 
 	vbds, err := cs.xoaClient.GetVBDsByVDI(ctx, vdi.UUID)
 	if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "failed to get VBDs: %v", err)
+		return nil, nil, translateXOAErrorToCSI(err, "failed to get VBDs")
 	}
 	if len(vbds) > 0 {
 		return nil, nil, status.Errorf(codes.Unavailable, "VDI is attached to at least one VM, we can not migrate it, while it is attached")
@@ -771,14 +774,14 @@ func (cs *ControllerService) migrateVDI(ctx context.Context, vdi *xoa.VDI, vm *x
 	err = cs.xoaClient.EditVDI(ctx, vdi.UUID, nil, ptr.To(storageInfo.ToVDIDescription()))
 	if err != nil {
 		log.Error(err, "failed to set VDI description")
-		return nil, nil, status.Errorf(codes.Internal, "failed to set VDI description: %v", err)
+		return nil, nil, translateXOAErrorToCSI(err, "failed to set VDI description")
 	}
 
 	log.Info("Migrating VDI", "vdiUUID", vdi.UUID, "targetSRUUID", pickedSR.UUID)
 	newVdiUUID, err := cs.xoaClient.MigrateVDI(ctx, vdi.UUID, pickedSR.UUID)
 	if err != nil {
 		log.Error(err, "failed to migrate VDI")
-		return nil, nil, status.Errorf(codes.Internal, "failed to migrate VDI: %v", err)
+		return nil, nil, translateXOAErrorToCSI(err, "failed to migrate VDI")
 	}
 	log.Info("VDI migrated", "vdiUUID", vdi.UUID, "targetSRUUID", pickedSR.UUID, "newVdiUUID", newVdiUUID)
 
@@ -786,7 +789,7 @@ func (cs *ControllerService) migrateVDI(ctx context.Context, vdi *xoa.VDI, vm *x
 	if errors.Is(err, xoa.ErrObjectNotFound) {
 		return nil, nil, status.Errorf(codes.NotFound, "Migrated VDI not found")
 	} else if err != nil {
-		return nil, nil, status.Errorf(codes.Internal, "failed to get VDI: %v", err)
+		return nil, nil, translateXOAErrorToCSI(err, "failed to get VDI")
 	}
 
 	// Remove the migration description from the new VDI
@@ -794,7 +797,7 @@ func (cs *ControllerService) migrateVDI(ctx context.Context, vdi *xoa.VDI, vm *x
 	err = cs.xoaClient.EditVDI(ctx, foundVdi.UUID, nil, ptr.To(storageInfo.ToVDIDescription()))
 	if err != nil {
 		log.Error(err, "failed to set VDI description")
-		return nil, nil, status.Errorf(codes.Internal, "failed to set VDI description: %v", err)
+		return nil, nil, translateXOAErrorToCSI(err, "failed to set VDI description")
 	}
 
 	log.Info("VDI finished migration", "vdiUUID", foundVdi.UUID, "targetSRUUID", pickedSR.UUID)
@@ -807,7 +810,7 @@ func (cs *ControllerService) getOneDiskAndDeleteRest(ctx context.Context, name s
 		"name_label": name,
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get disks: %v", err)
+		return nil, translateXOAErrorToCSI(err, "failed to get disks")
 	}
 
 	if len(vdis) == 0 {
@@ -825,4 +828,26 @@ func (cs *ControllerService) getOneDiskAndDeleteRest(ctx context.Context, name s
 	}
 
 	return selectedVdi, nil
+}
+
+// translateXOAErrorToCSI translates only common XOA client errors that can be safely
+// translated to CSI gRPC codes without specific context handling.
+func translateXOAErrorToCSI(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, xoa.ErrConnectionError):
+		return status.Errorf(codes.Unavailable, "%s: connection error: %v", operation, err)
+	case errors.Is(err, xoa.ErrUnauthorized):
+		return status.Errorf(codes.PermissionDenied, "%s: not enough permissions: %v", operation, err)
+	case errors.Is(err, xoa.ErrForbiddenOperation):
+		return status.Errorf(codes.PermissionDenied, "%s: forbidden operation: %v", operation, err)
+	case errors.Is(err, xoa.ErrNotEnoughResources):
+		return status.Errorf(codes.ResourceExhausted, "%s: not enough resources: %v", operation, err)
+	default:
+		// For any unhandled errors, return as unknown error
+		return status.Errorf(codes.Unknown, "%s: %v", operation, err)
+	}
 }

--- a/pkg/xoa/errors.go
+++ b/pkg/xoa/errors.go
@@ -26,7 +26,6 @@ var (
 	// Connection errors
 	ErrConnectionError      = errors.New("connection error")
 	ErrInvalidArgument      = errors.New("invalid argument")
-	ErrAlreadyConnected     = errors.New("already connected")
 	ErrUnmarshalError       = errors.New("unmarshalling error")
 	ErrNotImplemented       = errors.New("not implemented (client)")
 	ErrMultipleObjectsFound = errors.New("multiple objects found")

--- a/pkg/xoa/errors.go
+++ b/pkg/xoa/errors.go
@@ -18,11 +18,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/sourcegraph/jsonrpc2"
 )
 
 var (
 	// Connection errors
-	ErrContextCancelled     = errors.New("context cancelled")
 	ErrConnectionError      = errors.New("connection error")
 	ErrInvalidArgument      = errors.New("invalid argument")
 	ErrAlreadyConnected     = errors.New("already connected")
@@ -36,7 +37,7 @@ var (
 )
 
 // ConvertJSONRPCError converts an JSONRPCError to a specific error type based on the code
-func ConvertJSONRPCError(apiErr *jsonRPCError) error {
+func ConvertJSONRPCError(apiErr *jsonrpc2.Error) error {
 	if specificErr, exists := errorCodeMap[apiErr.Code]; exists {
 		return fmt.Errorf("%w: %s", specificErr, apiErr.Message)
 	}
@@ -100,7 +101,7 @@ var (
 )
 
 // errorCodeMap maps error codes to their corresponding error types
-var errorCodeMap = map[int]error{
+var errorCodeMap = map[int64]error{
 	// General errors
 	0:  ErrNotImplementedOnServer,
 	1:  ErrNoSuchObject,

--- a/pkg/xoa/jsonrpc_client.go
+++ b/pkg/xoa/jsonrpc_client.go
@@ -96,7 +96,7 @@ func (c *jsonRPCClient) connect(ctx context.Context) error {
 	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		if wsConn != nil {
-			wsConn.Close()
+			_ = wsConn.Close()
 		}
 		return fmt.Errorf("%w: failed to connect to WebSocket: %w", ErrConnectionError, err)
 	}
@@ -144,7 +144,7 @@ func (c *jsonRPCClient) closeConnection() {
 		return
 	}
 
-	c.conn.Close()
+	_ = c.conn.Close()
 	c.conn = nil
 }
 

--- a/pkg/xoa/jsonrpc_client.go
+++ b/pkg/xoa/jsonrpc_client.go
@@ -48,7 +48,7 @@ func NewJSONRPCClient(config ClientConfig) (*jsonRPCClient, error) {
 
 	// Set default values
 	if config.Timeout == 0 {
-		config.Timeout = 30 * time.Second
+		config.Timeout = 300 * time.Second
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -119,8 +119,11 @@ func (c *jsonRPCClient) Close() error {
 
 // Call makes a JSON-RPC call and waits for the response
 func (c *jsonRPCClient) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	callctx, cancel := context.WithTimeout(ctx, c.config.Timeout)
+	defer cancel()
+
 	var result json.RawMessage
-	err := c.conn.Call(ctx, method, params, &result)
+	err := c.conn.Call(callctx, method, params, &result)
 	if err != nil {
 		switch err := err.(type) {
 		case *jsonrpc2.Error:

--- a/pkg/xoa/jsonrpc_client_test.go
+++ b/pkg/xoa/jsonrpc_client_test.go
@@ -21,11 +21,9 @@ import (
 
 func TestNewClient(t *testing.T) {
 	config := ClientConfig{
-		BaseURL:    "https://xo.company.lan",
-		Token:      "test-token",
-		Timeout:    30 * time.Second,
-		RetryCount: 3,
-		RetryWait:  1 * time.Second,
+		BaseURL: "https://xo.company.lan",
+		Token:   "test-token",
+		Timeout: 30 * time.Second,
 	}
 
 	client, err := NewJSONRPCClient(config)

--- a/pkg/xoa/types.go
+++ b/pkg/xoa/types.go
@@ -21,11 +21,9 @@ import (
 
 // Config holds the configuration for the Xen Orchestra API client
 type ClientConfig struct {
-	BaseURL    string
-	Token      string
-	Timeout    time.Duration
-	RetryCount int
-	RetryWait  time.Duration
+	BaseURL string
+	Token   string
+	Timeout time.Duration
 }
 
 // Client defines the interface for Xen Orchestra API operations

--- a/pkg/xoa/types.go
+++ b/pkg/xoa/types.go
@@ -23,7 +23,7 @@ import (
 type ClientConfig struct {
 	BaseURL string
 	Token   string
-	Timeout time.Duration
+	Timeout time.Duration // Timeout for API calls
 }
 
 // Client defines the interface for Xen Orchestra API operations


### PR DESCRIPTION
* maintainability: We now use `sourcegraph/jsonrpc2` instead of rolling our own jsonrpc2
* improvement: re-connecting of broken websocket/jsonrpc connections
* improvement:  translation of XOA errors to CSI codes. (e.g. connection errors now map to `Unavailable`

This now makes e2e-tests pass even if the xen-orchestra is restarted (repeatedly) during the tests.
